### PR TITLE
Add Random Note++

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2286,5 +2286,13 @@
         "author": "tillahoffmann",
         "description": "Run python code in Obsidian using jupyter.",
         "repo": "tillahoffmann/obsidian-jupyter"
+    },
+    {
+        "id": "random-note-plus-plus",
+        "name": "Random note++",
+        "description": "Like the built-in Random note, but also has a command to select a random file in a configured folder or current folder",
+        "author": "jkomoros",
+        "repo": "jkomoros/random-note-plus-plus",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
Adds random-note-plus-plus plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/jkomoros/random-note-plus-plus

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
